### PR TITLE
📦 Publish to NuGet

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,11 +32,6 @@ jobs:
         run: dotnet pack -c release --no-build
       # End ci-build.ps1
 
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4.0.1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Full depth (not shallow) for better relevancy of Sonar analysis
+
+      - name: Use .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      # Begin ci-build.ps1
+      - name: dotnet restore
+        run: dotnet restore
+
+      - name: dotnet build
+        run: dotnet build -c release --no-restore
+
+      - name: dotnet pack
+        run: dotnet pack -c release --no-build
+      # End ci-build.ps1
+
+      - name: dotnet nuget push
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: >-
+          dotnet nuget push
+          /artifacts/package/release/*.nupkg
+          --api-key $NUGET_AUTH_TOKEN
+          --no-symbols
+          --skip-duplicate
+          --source https://api.nuget.org/v3/index.json
+        env:
+          NUGET_AUTH_TOKEN: ${{ secrets.NUGET_AUTH_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,17 @@ jobs:
         run: dotnet pack -c release --no-build
       # End ci-build.ps1
 
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4.0.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
       - name: dotnet nuget push
         if: ${{ github.ref == 'refs/heads/main' }}
         run: >-

--- a/ci-build.ps1
+++ b/ci-build.ps1
@@ -1,0 +1,9 @@
+$env:CI = true
+
+try {
+	dotnet restore
+	dotnet build -c release --no-restore
+	dotnet pack -c release --no-build
+} finally {
+	$env:CI = $null
+}

--- a/connorjs-analyzers.sln
+++ b/connorjs-analyzers.sln
@@ -10,9 +10,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "root", "root", "{E393E29D-8
 		.editorconfig = .editorconfig
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
+		ci-build.ps1 = ci-build.ps1
 		directory.build.props = directory.build.props
+		global.json = global.json
 		LICENSE = LICENSE
 		README.md = README.md
+		.github\workflows\ci.yaml = .github\workflows\ci.yaml
 	EndProjectSection
 EndProject
 Global

--- a/connorjs-analyzers/connorjs-analyzers.csproj
+++ b/connorjs-analyzers/connorjs-analyzers.csproj
@@ -2,6 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<RootNamespace>ConnorJS.Analyzers</RootNamespace>
+		<EnablePackageValidation>true</EnablePackageValidation>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -24,4 +25,11 @@
 		<PackageReference Include="SonarAnalyzer.CSharp" Version="9.28.0.94264" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
 	</ItemGroup>
+
+	<PropertyGroup>
+		<!--
+		- NU5104: Suppress warning about prerelease StyleCop package.
+		-->
+		<NoWarn>NU5104</NoWarn>
+	</PropertyGroup>
 </Project>

--- a/directory.build.props
+++ b/directory.build.props
@@ -2,4 +2,8 @@
 	<PropertyGroup>
 		<UseArtifactsOutput>true</UseArtifactsOutput>
 	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(CI)' == 'true'">
+		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+	</PropertyGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+	"sdk": {
+		"rollForward": "latestFeature",
+		"version": "8.0.300"
+	}
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,5 @@
+sonar.projectKey=connorjs_connorjs-analyzers
+sonar.organization=connorjs
+
+# Only source, no tests
+sonar.sources=connorjs-analyzers


### PR DESCRIPTION
Adds CI workflow to build the package during PR and CI. It publishes the package to NuGet when running on `main` (not in PR).

It does not (yet) auto-version the package.