### PR TITLE
♻️ Change GitVersion execution to pipeline

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Full depth (not shallow) for better relevancy of Sonar analysis
+          fetch-depth: 0 # Full depth (not shallow) for GitVersion and better relevancy of Sonar analysis
+
+      - name: Set up GitVersion
+        uses: gittools/actions/gitversion/setup@v2.0.1
+        with:
+          versionSpec: 6.x
+
+      - name: Execute GitVersion
+        uses: gittools/actions/gitversion/execute@v2.0.1
+        with:
+          useConfigFile: true
+          updateAssemblyInfo: true
 
       - name: Use .NET
         uses: actions/setup-dotnet@v4
@@ -49,3 +60,14 @@ jobs:
           --source https://api.nuget.org/v3/index.json
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.NUGET_AUTH_TOKEN }}
+
+      - name: TEST
+        run: |
+          git tag v${{ env.SemVer }}
+          echo v${{ env.SemVer }}
+
+      - name: git tag
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: |
+          git tag v${{ env.SemVer }}
+          git push origin tag v${{ env.SemVer }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,11 +63,11 @@ jobs:
 
       - name: TEST
         run: |
-          git tag v${{ env.SemVer }}
-          echo v${{ env.SemVer }}
+          git tag v${{ env.GitVersion_SemVer }}
+          echo v${{ env.GitVersion_SemVer }}
 
       - name: git tag
         if: ${{ github.ref == 'refs/heads/main' }}
         run: |
-          git tag v${{ env.SemVer }}
-          git push origin tag v${{ env.SemVer }}
+          git tag v${{ env.GitVersion_SemVer }}
+          git push origin tag v${{ env.GitVersion_SemVer }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,8 +25,7 @@ jobs:
         uses: gittools/actions/gitversion/execute@v2.0.1
         with:
           useConfigFile: true
-          additionalArguments: >-
-            -updateprojectfiles
+          additionalArguments: /updateprojectfiles
 
       - name: Use .NET
         uses: actions/setup-dotnet@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,8 @@ jobs:
         uses: gittools/actions/gitversion/execute@v2.0.1
         with:
           useConfigFile: true
-          updateAssemblyInfo: true
+          additionalArguments: >-
+            -updateprojectfiles
 
       - name: Use .NET
         uses: actions/setup-dotnet@v4
@@ -60,11 +61,6 @@ jobs:
           --source https://api.nuget.org/v3/index.json
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.NUGET_AUTH_TOKEN }}
-
-      - name: TEST
-        run: |
-          git tag v${{ env.GitVersion_SemVer }}
-          echo v${{ env.GitVersion_SemVer }}
 
       - name: git tag
         if: ${{ github.ref == 'refs/heads/main' }}

--- a/connorjs-analyzers/connorjs-analyzers.csproj
+++ b/connorjs-analyzers/connorjs-analyzers.csproj
@@ -7,7 +7,6 @@
 
 	<PropertyGroup>
 		<PackageId>connorjs-analyzers</PackageId>
-		<PackageVersion>0.0.0-gitversion</PackageVersion>
 		<Authors>Connor Sullivan</Authors>
 		<Description>@connorjs’s personal .NET analyzer package</Description>
 		<DevelopmentDependency>true</DevelopmentDependency>

--- a/connorjs-analyzers/connorjs-analyzers.csproj
+++ b/connorjs-analyzers/connorjs-analyzers.csproj
@@ -7,6 +7,7 @@
 
 	<PropertyGroup>
 		<PackageId>connorjs-analyzers</PackageId>
+		<PackageVersion>0.0.0-gitversion</PackageVersion>
 		<Authors>Connor Sullivan</Authors>
 		<Description>@connorjs’s personal .NET analyzer package</Description>
 		<DevelopmentDependency>true</DevelopmentDependency>

--- a/connorjs-analyzers/connorjs-analyzers.csproj
+++ b/connorjs-analyzers/connorjs-analyzers.csproj
@@ -24,7 +24,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="GitVersion.MsBuild" Version="6.0.0" PrivateAssets="all" />
 		<PackageReference Include="SonarAnalyzer.CSharp" Version="9.28.0.94264" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
 	</ItemGroup>


### PR DESCRIPTION
Changes GitVersion execution from MSBuild package to GitHub action step. This simplifies tagging the release for GitVersion (and for GitHub).