### PR TITLE
📦 Set up GitHub releases

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  REPO_NAME: ${{ github.event.repository.name }}
+
 jobs:
   build:
     name: Build
@@ -26,6 +29,10 @@ jobs:
         with:
           useConfigFile: true
           additionalArguments: /updateprojectfiles
+
+      - name: Set nupkg path (GitVersion-ed)
+        run: |
+          echo 'NUPKG_PATH=artifacts/package/release/${{ REPO_NAME }}.${{ env.GitVersion_SemVer }}.nupkg' >> "$GITHUB_ENV"
 
       - name: Use .NET
         uses: actions/setup-dotnet@v4
@@ -52,17 +59,21 @@ jobs:
       - name: dotnet nuget push
         if: ${{ github.ref == 'refs/heads/main' }}
         run: >-
-          dotnet nuget push
-          artifacts/package/release/*.nupkg
+          dotnet nuget push ${{ env.NUPKG_PATH }}
           --api-key $NUGET_AUTH_TOKEN
           --no-symbols
-          --skip-duplicate
           --source https://api.nuget.org/v3/index.json
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.NUGET_AUTH_TOKEN }}
 
-      - name: git tag
+      - uses: gittools/actions/gitreleasemanager/create@v2.0.1
         if: ${{ github.ref == 'refs/heads/main' }}
-        run: |
-          git tag v${{ env.GitVersion_SemVer }}
-          git push origin tag v${{ env.GitVersion_SemVer }}
+        name: Create release (GitReleaseManager)
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          owner: ${{ GITHUB_REPOSITORY_OWNER }}
+          repository: ${{ REPO_NAME }}
+          milestone: ${{ env.GitVersion_SemVer }}
+          name: v${{ env.GitVersion_SemVer }}
+          assets: |
+            ${{ env.NUPKG_PATH }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Set nupkg path (GitVersion-ed)
         run: |
-          echo 'NUPKG_PATH=artifacts/package/release/${{ REPO_NAME }}.${{ env.GitVersion_SemVer }}.nupkg' >> "$GITHUB_ENV"
+          echo 'NUPKG_PATH=artifacts/package/release/${{ env.REPO_NAME }}.${{ env.GitVersion_SemVer }}.nupkg' >> "$GITHUB_ENV"
 
       - name: Use .NET
         uses: actions/setup-dotnet@v4
@@ -71,8 +71,8 @@ jobs:
         name: Create release (GitReleaseManager)
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          owner: ${{ GITHUB_REPOSITORY_OWNER }}
-          repository: ${{ REPO_NAME }}
+          owner: ${{ env.GITHUB_REPOSITORY_OWNER }}
+          repository: ${{ env.REPO_NAME }}
           milestone: ${{ env.GitVersion_SemVer }}
           name: v${{ env.GitVersion_SemVer }}
           assets: |


### PR DESCRIPTION
Sets up GitHub releases with GitReleaseManager.

This should resolve the git tagging permission issue _and_ automate the release process, which improves CI/CD.