### PR TITLE
✨ Stylecop.json

### DIFF
--- a/connorjs-analyzers/build/connorjs-analyzers.globalconfig
+++ b/connorjs-analyzers/build/connorjs-analyzers.globalconfig
@@ -71,10 +71,6 @@ dotnet_diagnostic.SA1518.severity = none
 
 # StyleCop - https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/DOCUMENTATION.md
 
-## Special rules - https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SpecialRules.md
-; Not all projects need to generate XML Documentation. Trust projects to enable `GenerateDocumentationFile` if needed.
-dotnet_diagnostic.SA0001.severity = none
-
 ## Documentation - https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/DocumentationRules.md
-; Do not need file header.
+; Do not need file header (repository licenses should suffice)
 dotnet_diagnostic.SA1633.severity = none

--- a/connorjs-analyzers/build/connorjs-analyzers.props
+++ b/connorjs-analyzers/build/connorjs-analyzers.props
@@ -1,6 +1,7 @@
 <Project>
 	<ItemGroup>
 		<GlobalAnalyzerConfigFiles Include="$(MSBuildThisFileDirectory)connorjs-analyzers.globalconfig" />
+		<AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Link="stylecop.json" />
 	</ItemGroup>
 
 	<!-- MSBuild properties (for .NET) -->

--- a/connorjs-analyzers/build/stylecop.json
+++ b/connorjs-analyzers/build/stylecop.json
@@ -1,0 +1,8 @@
+{
+	"$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
+	"settings": {
+		"documentationRules": {
+			"documentInternalElements": false
+		}
+	}
+}


### PR DESCRIPTION
Adds `stylecop.json` to not require documentation for internal elements. Adds back XML documentation warning.

semver:minor